### PR TITLE
Adds a npm download trend link

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Please read the [github contribution guide](https://docs.github.com/en/get-start
 - Commit and push your code
 - Open a Pull Request
 
+## Usage Trends of Tango
+
+[Usage Trends of Tango Packages](https://npm-compare.com/@music163/tango-helpers,@music163/tango-context,@music163/tango-core,@music163/tango-setting-form,@music163/tango-sandbox,@music163/tango-ui,@music163/tango-designer)
+
 ## 💗 Acknowledgments
 
 Thanks to the NetEase Cloud Music Front-end team, Public Technology team, Live Broadcasting Technology team, and all the colleagues who participated in the Tango project.
 
 Thank you to CodeSandbox for providing the [Sandpack](https://sandpack.codesandbox.io/) project, which provides powerful online code execution capabilities for Tango.
-
-## Usage Trends of Tango
-
-[Usage Trends of Tango Packages](https://npm-compare.com/@music163/tango-helpers,@music163/tango-context,@music163/tango-core,@music163/tango-setting-form,@music163/tango-sandbox,@music163/tango-ui,@music163/tango-designer)

--- a/README.md
+++ b/README.md
@@ -123,3 +123,7 @@ Please read the [github contribution guide](https://docs.github.com/en/get-start
 Thanks to the NetEase Cloud Music Front-end team, Public Technology team, Live Broadcasting Technology team, and all the colleagues who participated in the Tango project.
 
 Thank you to CodeSandbox for providing the [Sandpack](https://sandpack.codesandbox.io/) project, which provides powerful online code execution capabilities for Tango.
+
+## Usage Trends of Tango
+
+[Usage Trends of Tango Packages](https://npm-compare.com/@music163/tango-helpers,@music163/tango-context,@music163/tango-core,@music163/tango-setting-form,@music163/tango-sandbox,@music163/tango-ui,@music163/tango-designer)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,10 @@ yarn start
 - 合并修改 git rebase master
 - 发起 Pull Request
 
+## Tango使用量趋势
+
+[Tango使用量趋势](https://npm-compare.com/@music163/tango-helpers,@music163/tango-context,@music163/tango-core,@music163/tango-setting-form,@music163/tango-sandbox,@music163/tango-ui,@music163/tango-designer)
+
 ## 💗 致谢
 
 感谢网易云音乐公共技术团队，大前端团队，直播技术团队，以及所有参与过 Tango 项目的同学们。


### PR DESCRIPTION
This merge request adds a npm download trend link to the NetEase/tango repository.

Users can gain valuable insights into the popularity and usage of the package through download trend data, enabling them to make data-driven decisions. Foster a sense of transparency by sharing important metrics related to the package's usage.

We appreciate your the hard work put into this awesome repo.