### PR TITLE
Optimize the logic of finding parent JSX nodes

### DIFF
--- a/packages/core/src/helpers/ast/traverse.ts
+++ b/packages/core/src/helpers/ast/traverse.ts
@@ -1216,9 +1216,10 @@ export function traverseViewFile(ast: t.File, idGenerator: IdGenerator) {
 
       // parentId 用于追溯上下游关系
       let parentId;
-      const parentNode = path.parentPath.node;
-      if (t.isJSXElement(parentNode)) {
-        const parentAttributes = getJSXElementAttributes(parentNode);
+      const parentNode = path.findParent((p) => p.isJSXElement());
+
+      if (t.isJSXElement(parentNode?.node)) {
+        const parentAttributes = getJSXElementAttributes(parentNode.node);
         parentId = parentAttributes[SLOT.dnd];
       }
 


### PR DESCRIPTION
Optimize the logic of finding parent JSX nodes and be compatible with following such as :

```javascript
<Page>
	<Component renderItem={()=> <Box></Box>}><Component/>
</Page>
```