### PR TITLE
feat: designer model add defaultActiveSidebarPanel

### DIFF
--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -34,8 +34,7 @@ const workspace = new Workspace({
 // 2. 引擎初始化
 const engine = createEngine({
   workspace,
-  // defaultActiveSidebarPanel: 'components',
-  // defaultAddComponentType: 'click'
+  defaultActiveSidebarPanel: 'outline',
 });
 
 // @ts-ignore

--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -34,6 +34,8 @@ const workspace = new Workspace({
 // 2. 引擎初始化
 const engine = createEngine({
   workspace,
+  // defaultActiveSidebarPanel: 'components',
+  // defaultAddComponentType: 'click'
 });
 
 // @ts-ignore

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,4 +1,4 @@
-import { Designer, Engine, SimulatorNameType } from './models';
+import { Designer, DesignerAddComponentType, Engine, SimulatorNameType } from './models';
 import { IWorkspace } from './models/interfaces';
 
 interface ICreateEngineOptions {
@@ -10,6 +10,14 @@ interface ICreateEngineOptions {
    * 默认的模拟器模式
    */
   defaultSimulatorMode?: SimulatorNameType;
+  /**
+   * 默认的组件添加方式
+   */
+  defaultAddComponentType?: DesignerAddComponentType;
+  /**
+   * 默认激活的侧边栏
+   */
+  defaultActiveSidebarPanel?: string;
 }
 
 /**
@@ -20,12 +28,16 @@ interface ICreateEngineOptions {
 export function createEngine({
   workspace,
   defaultSimulatorMode = 'desktop',
+  defaultAddComponentType = 'drag',
+  defaultActiveSidebarPanel = '',
 }: ICreateEngineOptions) {
   const engine = new Engine({
     workspace,
     designer: new Designer({
       workspace,
       simulator: defaultSimulatorMode,
+      addComponentType: defaultAddComponentType,
+      activeSidebarPanel: defaultActiveSidebarPanel,
     }),
   });
 

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,4 +1,4 @@
-import { Designer, DesignerAddComponentType, Engine, SimulatorNameType } from './models';
+import { Designer, Engine, SimulatorNameType } from './models';
 import { IWorkspace } from './models/interfaces';
 
 interface ICreateEngineOptions {
@@ -10,10 +10,6 @@ interface ICreateEngineOptions {
    * 默认的模拟器模式
    */
   defaultSimulatorMode?: SimulatorNameType;
-  /**
-   * 默认的组件添加方式
-   */
-  defaultAddComponentType?: DesignerAddComponentType;
   /**
    * 默认激活的侧边栏
    */
@@ -28,7 +24,6 @@ interface ICreateEngineOptions {
 export function createEngine({
   workspace,
   defaultSimulatorMode = 'desktop',
-  defaultAddComponentType = 'drag',
   defaultActiveSidebarPanel = '',
 }: ICreateEngineOptions) {
   const engine = new Engine({
@@ -36,7 +31,6 @@ export function createEngine({
     designer: new Designer({
       workspace,
       simulator: defaultSimulatorMode,
-      addComponentType: defaultAddComponentType,
       activeSidebarPanel: defaultActiveSidebarPanel,
     }),
   });

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -16,12 +16,9 @@ interface ViewportBoundingType {
 
 export type DesignerViewType = 'design' | 'code';
 
-export type DesignerAddComponentType = 'drag' | 'click';
-
 interface DesignerOptionsType {
   workspace: IWorkspace;
   simulator?: SimulatorNameType | SimulatorType;
-  addComponentType?: DesignerAddComponentType;
   activeSidebarPanel?: string;
 }
 

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -68,12 +68,6 @@ export class Designer {
   _showSmartWizard = false;
 
   /**
-   * 添加组件方式
-   * 拖拽 or 点击
-   */
-  _addComponentType: DesignerAddComponentType = 'drag';
-
-  /**
    * 是否显示右侧面板
    */
   _showRightPanel = true;
@@ -118,23 +112,14 @@ export class Designer {
     return this._showRightPanel;
   }
 
-  get addComponentType() {
-    return this._addComponentType;
-  }
-
   constructor(options: DesignerOptionsType) {
     this.workspace = options.workspace;
 
-    const { simulator, addComponentType, activeSidebarPanel: defaultActiveSidebarPanel } = options;
+    const { simulator, activeSidebarPanel: defaultActiveSidebarPanel } = options;
 
     // 默认设计器模式
     if (simulator) {
       this.setSimulator(simulator);
-    }
-
-    // 添加组件方式(默认为拖拽)
-    if (addComponentType) {
-      this.setAddComponentType(addComponentType);
     }
 
     // 默认展开的侧边栏
@@ -150,8 +135,6 @@ export class Designer {
       _showSmartWizard: observable,
       _showRightPanel: observable,
       _isPreview: observable,
-      _addComponentType: observable,
-      addComponentType: computed,
       simulator: computed,
       viewport: computed,
       activeView: computed,
@@ -167,7 +150,6 @@ export class Designer {
       toggleRightPanel: action,
       toggleSmartWizard: action,
       toggleIsPreview: action,
-      setAddComponentType: action,
     });
   }
 
@@ -194,11 +176,6 @@ export class Designer {
       this._activeSidebarPanel = '';
     }
   }
-
-  setAddComponentType(value: DesignerAddComponentType) {
-    this._addComponentType = value;
-  }
-
   closeSidebarPanel() {
     this._activeSidebarPanel = '';
   }

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -3,20 +3,27 @@ import { IWorkspace } from './interfaces';
 
 export type SimulatorNameType = 'desktop' | 'phone';
 
-type SimulatorType = {
+interface SimulatorType {
   name: SimulatorNameType;
   width: number;
   height: number;
-};
+}
 
-type ViewportBoundingType = {
+interface ViewportBoundingType {
   width: number;
   height: number;
-};
+}
 
 export type DesignerViewType = 'design' | 'code';
 
-type DesignerOptionsType = { workspace: IWorkspace; simulator?: SimulatorNameType | SimulatorType };
+export type DesignerAddComponentType = 'drag' | 'click';
+
+interface DesignerOptionsType {
+  workspace: IWorkspace;
+  simulator?: SimulatorNameType | SimulatorType;
+  addComponentType?: DesignerAddComponentType;
+  activeSidebarPanel?: string;
+}
 
 const simulatorTypes: Record<string, SimulatorType> = {
   desktop: {
@@ -61,6 +68,12 @@ export class Designer {
   _showSmartWizard = false;
 
   /**
+   * 添加组件方式
+   * 拖拽 or 点击
+   */
+  _addComponentType: DesignerAddComponentType = 'drag';
+
+  /**
    * 是否显示右侧面板
    */
   _showRightPanel = true;
@@ -69,6 +82,11 @@ export class Designer {
    * 是否预览模式
    */
   _isPreview = false;
+
+  /**
+   * 默认展开的侧边栏
+   */
+  defaultActiveSidebarPanel?: string;
 
   private readonly workspace: IWorkspace;
 
@@ -100,11 +118,30 @@ export class Designer {
     return this._showRightPanel;
   }
 
+  get addComponentType() {
+    return this._addComponentType;
+  }
+
   constructor(options: DesignerOptionsType) {
     this.workspace = options.workspace;
-    if (options.simulator) {
-      this.setSimulator(options.simulator);
+
+    const { simulator, addComponentType, activeSidebarPanel: defaultActiveSidebarPanel } = options;
+
+    // 默认设计器模式
+    if (simulator) {
+      this.setSimulator(simulator);
     }
+
+    // 添加组件方式(默认为拖拽)
+    if (addComponentType) {
+      this.setAddComponentType(addComponentType);
+    }
+
+    // 默认展开的侧边栏
+    if (defaultActiveSidebarPanel) {
+      this.setActiveSidebarPanel(defaultActiveSidebarPanel);
+    }
+
     makeObservable(this, {
       _simulator: observable,
       _viewport: observable,
@@ -113,6 +150,8 @@ export class Designer {
       _showSmartWizard: observable,
       _showRightPanel: observable,
       _isPreview: observable,
+      _addComponentType: observable,
+      addComponentType: computed,
       simulator: computed,
       viewport: computed,
       activeView: computed,
@@ -128,6 +167,7 @@ export class Designer {
       toggleRightPanel: action,
       toggleSmartWizard: action,
       toggleIsPreview: action,
+      setAddComponentType: action,
     });
   }
 
@@ -153,6 +193,10 @@ export class Designer {
     } else {
       this._activeSidebarPanel = '';
     }
+  }
+
+  setAddComponentType(value: DesignerAddComponentType) {
+    this._addComponentType = value;
   }
 
   closeSidebarPanel() {

--- a/packages/designer/src/sidebar/components-panel.tsx
+++ b/packages/designer/src/sidebar/components-panel.tsx
@@ -8,9 +8,9 @@ import {
   upperCamelCase,
 } from '@music163/tango-helpers';
 import { CollapsePanel, IconFont, Search, Tabs } from '@music163/tango-ui';
-import { observer, useDesigner, useWorkspace } from '@music163/tango-context';
+import { observer, useWorkspace } from '@music163/tango-context';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Button, Empty, Spin, Popover, message } from 'antd';
+import { Button, Empty, Spin, Popover } from 'antd';
 import { getDragGhostElement } from '../helpers';
 
 type MenuKeyType = 'common' | 'atom' | 'snippet' | 'block' | 'bizComp';
@@ -270,9 +270,6 @@ const StyledCommonGridItem = styled.div`
 
 function MaterialGrid({ data, type }: MaterialProps) {
   const workspace = useWorkspace();
-  const designer = useDesigner();
-  const { addComponentType } = designer;
-  const isDragAddType = addComponentType === 'drag';
 
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move';
@@ -289,27 +286,14 @@ function MaterialGrid({ data, type }: MaterialProps) {
     workspace.dragSource.clear();
   };
 
-  // 点击方式添加
-  const handleClick = () => {
-    if (!isDragAddType) {
-      if (workspace.selectSource.isSelected) {
-        workspace.insertToSelectedNode(data);
-        message.success(`${data.name} 已添加`);
-      } else {
-        message.warning('请选择一个节点');
-      }
-    }
-  };
-
   const icon = data.icon || 'icon-placeholder';
 
   return (
     <StyledCommonGridItem
-      draggable={isDragAddType}
+      draggable
       data-name={data.name}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      onClick={handleClick}
       className={type === 'block' ? 'block-item' : null}
     >
       {icon.startsWith('icon-') ? (

--- a/packages/designer/src/sidebar/components-panel.tsx
+++ b/packages/designer/src/sidebar/components-panel.tsx
@@ -8,9 +8,9 @@ import {
   upperCamelCase,
 } from '@music163/tango-helpers';
 import { CollapsePanel, IconFont, Search, Tabs } from '@music163/tango-ui';
-import { observer, useWorkspace } from '@music163/tango-context';
+import { observer, useDesigner, useWorkspace } from '@music163/tango-context';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Button, Empty, Spin, Popover } from 'antd';
+import { Button, Empty, Spin, Popover, message } from 'antd';
 import { getDragGhostElement } from '../helpers';
 
 type MenuKeyType = 'common' | 'atom' | 'snippet' | 'block' | 'bizComp';
@@ -270,6 +270,9 @@ const StyledCommonGridItem = styled.div`
 
 function MaterialGrid({ data, type }: MaterialProps) {
   const workspace = useWorkspace();
+  const designer = useDesigner();
+  const { addComponentType } = designer;
+  const isDragAddType = addComponentType === 'drag';
 
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move';
@@ -286,14 +289,27 @@ function MaterialGrid({ data, type }: MaterialProps) {
     workspace.dragSource.clear();
   };
 
+  // 点击方式添加
+  const handleClick = () => {
+    if (!isDragAddType) {
+      if (workspace.selectSource.isSelected) {
+        workspace.insertToSelectedNode(data);
+        message.success(`${data.name} 已添加`);
+      } else {
+        message.warning('请选择一个节点');
+      }
+    }
+  };
+
   const icon = data.icon || 'icon-placeholder';
 
   return (
     <StyledCommonGridItem
-      draggable
+      draggable={isDragAddType}
       data-name={data.name}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onClick={handleClick}
       className={type === 'block' ? 'block-item' : null}
     >
       {icon.startsWith('icon-') ? (


### PR DESCRIPTION
- 组件添加支持 点击/拖拽两种形式 (默认为拖拽)
- 支持配置默认展开的侧边栏

```js
const engine = createEngine({
  workspace,
  defaultActiveSidebarPanel: 'components', // components or outline or other sidebarpanel key ...
  defaultAddComponentType: 'click'  // click or drag
});
```