### PR TITLE
fix: outline-panel tree expand bug & add props

### DIFF
--- a/packages/designer/src/sidebar/outline-panel/components-tree.tsx
+++ b/packages/designer/src/sidebar/outline-panel/components-tree.tsx
@@ -1,13 +1,33 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Space, Tree } from 'antd';
+import { Dropdown, Space, Tree } from 'antd';
 import { Box, css } from 'coral-system';
 import { IconFont } from '@music163/tango-ui';
-import { EyeOutlined, EyeInvisibleOutlined } from '@ant-design/icons';
+import { EyeOutlined, EyeInvisibleOutlined, EllipsisOutlined } from '@ant-design/icons';
 import { observer, useWorkspace } from '@music163/tango-context';
 import { DropMethod, ITangoViewNodeData } from '@music163/tango-core';
-import { parseDndId } from '@music163/tango-helpers';
+import { noop, parseDndId } from '@music163/tango-helpers';
 import { useSandboxQuery } from '../../context';
 import { buildQueryBySlotId } from '../../helpers';
+
+export interface ComponentsTreeProps {
+  /**
+   * 显示/隐藏组件按钮,默认显示
+   */
+  showToggleVisibleIcon?: boolean;
+  /**
+   * 页面节点选中回调
+   */
+  onPageNodeSelect?: (nodeKey: string) => void;
+  /**
+   * 节点树更多功能菜单
+   */
+  actionItems?: ActionItem[];
+}
+
+interface ActionItem {
+  item: React.ReactNode;
+  key: string;
+}
 
 const outlineStyle = css`
   .ant-tree-title {
@@ -32,6 +52,9 @@ const outlineStyle = css`
   .ant-tree-switcher-noop {
     display: none;
   }
+  .material-icon {
+    width: 14px;
+  }
 `;
 
 const filedNames = {
@@ -51,132 +74,159 @@ const getNodeKeys = (data: ITangoViewNodeData[]) => {
   return ids;
 };
 
-const OutlineTreeNode: React.FC<any> = observer(({ node }: { node: ITangoViewNodeData }) => {
-  const workspace = useWorkspace();
-  const sandboxQuery = useSandboxQuery();
-  const [visible, setVisible] = useState(true);
-  const nodeLabel = useMemo(() => {
-    const { component, index } = parseDndId(node.id);
-    return `${component}:${index}`;
-  }, [node.id]);
-  const componentPrototype = workspace.componentPrototypes.get(node.component);
-  const icon = componentPrototype?.icon || 'icon-placeholder';
+const OutlineTreeNode: React.FC<{ node: ITangoViewNodeData } & ComponentsTreeProps> = observer(
+  ({ node, showToggleVisibleIcon, actionItems }) => {
+    const workspace = useWorkspace();
+    const sandboxQuery = useSandboxQuery();
+    const [visible, setVisible] = useState(true);
+    const nodeLabel = useMemo(() => {
+      const { component, index } = parseDndId(node.id);
+      return `${component}:${index}`;
+    }, [node.id]);
+    const componentPrototype = workspace.componentPrototypes.get(node.component);
+    const icon = componentPrototype?.icon || 'icon-placeholder';
 
-  const iconRender = icon.startsWith('icon-') ? (
-    <IconFont className="material-icon" type={icon} />
-  ) : (
-    <img src={icon} alt={componentPrototype.name} />
-  );
+    const iconRender = icon.startsWith('icon-') ? (
+      <IconFont className="material-icon" type={icon} />
+    ) : (
+      <img className="material-icon" src={icon} alt={componentPrototype.name} />
+    );
 
-  const toggleVisible = (nodeId: string) => {
-    sandboxQuery.getElement(buildQueryBySlotId(nodeId)).style.visibility = visible
-      ? 'hidden'
-      : 'visible';
-    setVisible(!visible);
-  };
+    const toggleVisible = (nodeId: string) => {
+      sandboxQuery.getElement(buildQueryBySlotId(nodeId)).style.visibility = visible
+        ? 'hidden'
+        : 'visible';
+      setVisible(!visible);
+    };
 
-  const VisibleIcon = visible ? EyeOutlined : EyeInvisibleOutlined;
-  return (
-    <Space>
-      {iconRender} {nodeLabel}
-      {/* 切换显示 */}
-      <VisibleIcon
-        className="material-icon"
-        onClick={(e) => {
-          e.stopPropagation();
-          toggleVisible(node.id);
-        }}
-      />
-    </Space>
-  );
-});
-
-export const ComponentsTree = observer(() => {
-  const workspace = useWorkspace();
-  const sandboxQuery = useSandboxQuery();
-  const [selectedKeys, setSelectedKeys] = useState<React.Key[]>(
-    workspace.selectSource.selected.map((item) => item.id),
-  );
-  const file = workspace.activeViewModule;
-  const nodesTree = file.nodesTree as ITangoViewNodeData[];
-
-  useEffect(() => {
-    setSelectedKeys(workspace.selectSource.selected.map((item) => item.id));
-  }, [workspace.selectSource.selected]);
-
-  if (!nodesTree.length) {
+    const VisibleIcon = visible ? EyeOutlined : EyeInvisibleOutlined;
     return (
-      <Box>
-        没有指定文件，或文件<code>{workspace.activeViewFile}</code>没有有效的节点树
+      <Space>
+        {iconRender} {nodeLabel}
+        {/* 切换显示 */}
+        {showToggleVisibleIcon && (
+          <VisibleIcon
+            className="material-icon"
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleVisible(node.id);
+            }}
+          />
+        )}
+        {/* 更多 ... 功能菜单 */}
+        {actionItems?.length > 0 && (
+          <Dropdown
+            menu={{
+              items: actionItems.map((_) => ({
+                key: _.key,
+                label: _.item,
+              })),
+            }}
+            trigger={['click']}
+          >
+            <EllipsisOutlined />
+          </Dropdown>
+        )}
+      </Space>
+    );
+  },
+);
+
+export const ComponentsTree: React.FC<ComponentsTreeProps> = observer(
+  ({ showToggleVisibleIcon = true, onPageNodeSelect = noop, actionItems }) => {
+    const workspace = useWorkspace();
+    const sandboxQuery = useSandboxQuery();
+    const [selectedKeys, setSelectedKeys] = useState<React.Key[]>(
+      workspace.selectSource.selected.map((item) => item.id),
+    );
+    const file = workspace.activeViewModule;
+    const nodesTree = (file?.nodesTree ?? []) as ITangoViewNodeData[];
+    const [expandedKeys, setExpandedKeys] = useState(getNodeKeys(nodesTree));
+
+    useEffect(() => {
+      setSelectedKeys(workspace.selectSource.selected.map((item) => item.id));
+    }, [workspace.selectSource.selected]);
+
+    if (!nodesTree.length) {
+      return (
+        <Box>
+          没有指定文件，或文件<code>{workspace.activeViewFile}</code>没有有效的节点树
+        </Box>
+      );
+    }
+
+    useEffect(() => {
+      setExpandedKeys(getNodeKeys(nodesTree));
+      // nodeTree 更新后重新计算expandKeys
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nodesTree?.[0]?.id]);
+
+    return (
+      <Box css={outlineStyle}>
+        <Tree
+          selectedKeys={selectedKeys}
+          fieldNames={filedNames}
+          treeData={nodesTree as any[]}
+          onSelect={(keys) => {
+            const slotKey = keys?.[0] as string;
+            const data = sandboxQuery.getDraggableParentsData(buildQueryBySlotId(slotKey), true);
+            if (data && data.id) {
+              workspace.selectSource.select({
+                id: data.id,
+                name: data.name,
+                bounding: data.bounding,
+                parents: data.parents,
+              });
+            }
+            // export selected
+            onPageNodeSelect(slotKey);
+            setSelectedKeys(keys);
+          }}
+          blockNode
+          expandedKeys={expandedKeys}
+          onExpand={(keys) => setExpandedKeys(keys as string[])}
+          draggable
+          onDragStart={(data) => {
+            const prototype = workspace.componentPrototypes.get(data.node.component);
+            if (!prototype) {
+              return;
+            }
+            const { canDrag } = prototype.rules || {};
+            if (canDrag && !canDrag()) {
+              return;
+            }
+            workspace.dragSource.set({
+              id: data.node.id,
+              name: data.node.component,
+            });
+          }}
+          onDrop={(data) => {
+            const dropKey = data.node.key as string;
+            let method;
+            if (data.dropToGap) {
+              // 插入节点的后面
+              method = DropMethod.InsertAfter;
+            } else {
+              // 作为第一个子节点
+              method = DropMethod.InsertFirstChild;
+            }
+            workspace.dragSource.dropTarget.set(
+              {
+                id: dropKey,
+              },
+              method,
+            );
+            workspace.dropNode();
+          }}
+          titleRender={(node) => (
+            <OutlineTreeNode
+              actionItems={actionItems}
+              showToggleVisibleIcon={showToggleVisibleIcon}
+              node={node}
+            />
+          )}
+        />
       </Box>
     );
-  }
-
-  useEffect(() => {
-    setExpandedKeys(getNodeKeys(nodesTree));
-    // nodeTree 更新后重新计算expandKeys
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodesTree?.[0]?.id]);
-
-  return (
-    <Box css={outlineStyle}>
-      <Tree
-        selectedKeys={selectedKeys}
-        fieldNames={filedNames}
-        treeData={nodesTree as any[]}
-        onSelect={(keys) => {
-          const data = sandboxQuery.getDraggableParentsData(
-            buildQueryBySlotId(keys[0] as string),
-            true,
-          );
-          if (data && data.id) {
-            workspace.selectSource.select({
-              id: data.id,
-              name: data.name,
-              bounding: data.bounding,
-              parents: data.parents,
-            });
-          }
-          setSelectedKeys(keys);
-        }}
-        blockNode
-        expandedKeys={expandedKeys}
-        onExpand={(keys) => setExpandedKeys(keys as string[])}
-        draggable
-        onDragStart={(data) => {
-          const prototype = workspace.componentPrototypes.get(data.node.component);
-          if (!prototype) {
-            return;
-          }
-          const { canDrag } = prototype.rules || {};
-          if (canDrag && !canDrag()) {
-            return;
-          }
-          workspace.dragSource.set({
-            id: data.node.id,
-            name: data.node.component,
-          });
-        }}
-        onDrop={(data) => {
-          const dropKey = data.node.key as string;
-          let method;
-          if (data.dropToGap) {
-            // 插入节点的后面
-            method = DropMethod.InsertAfter;
-          } else {
-            // 作为第一个子节点
-            method = DropMethod.InsertFirstChild;
-          }
-          workspace.dragSource.dropTarget.set(
-            {
-              id: dropKey,
-            },
-            method,
-          );
-          workspace.dropNode();
-        }}
-        titleRender={(node) => <OutlineTreeNode node={node} />}
-      />
-    </Box>
-  );
-});
+  },
+);

--- a/packages/designer/src/sidebar/outline-panel/components-tree.tsx
+++ b/packages/designer/src/sidebar/outline-panel/components-tree.tsx
@@ -112,6 +112,12 @@ export const ComponentsTree = observer(() => {
     );
   }
 
+  useEffect(() => {
+    setExpandedKeys(getNodeKeys(nodesTree));
+    // nodeTree 更新后重新计算expandKeys
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodesTree?.[0]?.id]);
+
   return (
     <Box css={outlineStyle}>
       <Tree
@@ -134,8 +140,8 @@ export const ComponentsTree = observer(() => {
           setSelectedKeys(keys);
         }}
         blockNode
-        autoExpandParent
-        expandedKeys={getNodeKeys(nodesTree)}
+        expandedKeys={expandedKeys}
+        onExpand={(keys) => setExpandedKeys(keys as string[])}
         draggable
         onDragStart={(data) => {
           const prototype = workspace.componentPrototypes.get(data.node.component);

--- a/packages/designer/src/sidebar/outline-panel/components-tree.tsx
+++ b/packages/designer/src/sidebar/outline-panel/components-tree.tsx
@@ -17,7 +17,7 @@ export interface ComponentsTreeProps {
   /**
    * 页面节点选中回调
    */
-  onPageNodeSelect?: (nodeKey: string) => void;
+  onSelect?: (nodeKey: string) => void;
   /**
    * 节点树更多功能菜单
    */
@@ -133,7 +133,7 @@ const OutlineTreeNode: React.FC<{ node: ITangoViewNodeData } & ComponentsTreePro
 );
 
 export const ComponentsTree: React.FC<ComponentsTreeProps> = observer(
-  ({ showToggleVisibleIcon = true, onPageNodeSelect = noop, actionItems }) => {
+  ({ showToggleVisibleIcon = true, onSelect = noop, actionItems }) => {
     const workspace = useWorkspace();
     const sandboxQuery = useSandboxQuery();
     const [selectedKeys, setSelectedKeys] = useState<React.Key[]>(
@@ -179,7 +179,7 @@ export const ComponentsTree: React.FC<ComponentsTreeProps> = observer(
               });
             }
             // export selected
-            onPageNodeSelect(slotKey);
+            onSelect(slotKey);
             setSelectedKeys(keys);
           }}
           blockNode

--- a/packages/designer/src/sidebar/outline-panel/index.tsx
+++ b/packages/designer/src/sidebar/outline-panel/index.tsx
@@ -2,20 +2,26 @@ import React from 'react';
 import { Box } from 'coral-system';
 import { CollapsePanel } from '@music163/tango-ui';
 import { StateTree } from './state-tree';
-import { ComponentsTree } from './components-tree';
+import { ComponentsTree, ComponentsTreeProps } from './components-tree';
 
-export interface OutlineViewProps {
+export interface OutlineViewProps extends ComponentsTreeProps {
   /**
    * 展示状态视图
    */
   showStateView?: boolean;
 }
 
-export function OutlinePanel({ showStateView = true }: OutlineViewProps) {
+export function OutlinePanel({ showStateView = true, ...treeProps }: OutlineViewProps) {
   return (
     <Box height="100%" position="relative">
-      <CollapsePanel title="页面结构" stickyHeader maxHeight="90%" overflowY="auto">
-        <ComponentsTree />
+      <CollapsePanel
+        title="页面结构"
+        maxHeight={showStateView ? '90%' : '100%'}
+        collapsed={!showStateView ? false : undefined}
+        overflowY="auto"
+        showBottomBorder={showStateView}
+      >
+        <ComponentsTree {...treeProps} />
       </CollapsePanel>
       {showStateView && (
         <CollapsePanel title="页面状态" stickyHeader maxHeight="90%" overflowY="auto">

--- a/packages/ui/src/collapse-panel.tsx
+++ b/packages/ui/src/collapse-panel.tsx
@@ -28,6 +28,10 @@ export interface CollapsePanelProps extends Omit<HTMLCoralProps<'div'>, 'title'>
    * 折叠状态变化时的回调
    */
   onCollapse?: (collapse: boolean) => void;
+  /**
+   * 是否显示底部边框线
+   */
+  showBottomBorder?: boolean;
 }
 
 const headerStyle = css`
@@ -49,6 +53,7 @@ export function CollapsePanel(props: CollapsePanelProps) {
     defaultCollapsed = false,
     onCollapse,
     stickyHeader,
+    showBottomBorder = true,
     ...rest
   } = props;
   const [collapsed, setCollapsed] = useControllableState({
@@ -70,8 +75,15 @@ export function CollapsePanel(props: CollapsePanelProps) {
       }
     : {};
 
+  const CollapsePanelBorderStyle = showBottomBorder
+    ? {
+        borderBottom: 'solid',
+        borderBottomColor: 'line2',
+      }
+    : {};
+
   return (
-    <Box className="CollapsePanel" borderBottom="solid" borderBottomColor="line2" {...rest}>
+    <Box className="CollapsePanel" {...CollapsePanelBorderStyle} {...rest}>
       <Box
         display="flex"
         alignItems="center"


### PR DESCRIPTION
fix:
- 修复点击展开/折叠node 失效bug

feat: 状态树 components-tree  
- 支持传入actionItems 声明dropdown功能按钮区域
- 新增 showToggleVisibleIcon 控制是否显示 👁 按钮
- 新增状态树节点点击回调事件 onPageNodeSelect
- 优化隐藏"页面状态"区域时 页面结构面板UI显示

feat: CollapsePanel
- 新增 showBottomBorder 属性控制是否显示 下边框border (默认显示)

```js
 <Sidebar.Item key="outline" label="结构" icon={<BuildOutlined />} 
	widgetProps={{
	  showStateView: false,
	  showToggleVisibleIcon: false,
	  actionItems: [
	    {
	      key: 'copy',
	      item: <Text onClick={() => workspace.cloneSelectedNode()}>复制</Text>
	    }
	  ],
	  onPageNodeSelect: (nodeKey: string) => {
	    console.log('onPageNodeSelect', nodeKey);
	  }
	}} 
/>

<CollapsePanel showBottomBorder={false}  />
```

![image](https://github.com/NetEase/tango/assets/25972237/2c000429-62db-434b-add2-2cad1b65a3d3)
