### PR TITLE
feat: custom component auto gen default prototype

### DIFF
--- a/apps/playground/src/mock/project.ts
+++ b/apps/playground/src/mock/project.ts
@@ -138,22 +138,25 @@ export default counter;
 const viewHomeCode = `
 import React from "react";
 import { definePage } from "@music163/tango-boot";
-import {
-  Page,
-  Section,
-  Button,
-  Input,
-  FormilyForm,
-} from "@music163/antd";
+import { Page, Section, Button, Input } from "@music163/antd";
+
+const CustomButton = (props) => {
+  return (
+    <div style={{ width: "60px", height: "25px" }} {...props}>
+      自定义按钮
+    </div>
+  );
+};
+
 class App extends React.Component {
   render() {
     return (
       <Page title={tango.stores.app.title}>
-       <Section title="Section Title">
-       </Section>
-       <Section>
+        <Section title="Section Title"></Section>
+        <Section>
           <Button>button</Button>
           <Input />
+          <CustomButton type="primary"/>
         </Section>
       </Page>
     );

--- a/packages/core/src/helpers/ast/traverse.ts
+++ b/packages/core/src/helpers/ast/traverse.ts
@@ -56,7 +56,7 @@ type JSXElementChildrenType = Array<
  * @param node
  * @param visitCallback
  */
-function visitJSXElementAttributes(
+export function visitJSXElementAttributes(
   node: t.JSXElement,
   visitCallback: (
     name: StringOrNumber,
@@ -337,6 +337,24 @@ export function removeJSXElement(ast: t.File, targetJSXElementNodeId: string) {
     },
   });
   return ast;
+}
+
+/**
+ * 根据 id 查找 JSXElement
+ * @param ast
+ * @param targetJSXElementNodeId
+ */
+export function findJSXElementById(ast: t.File, targetJSXElementNodeId: string) {
+  let targetJSXElement: t.JSXElement;
+  traverse(ast, {
+    JSXElement(path) {
+      if (isJSXElementById(path.node, targetJSXElementNodeId)) {
+        targetJSXElement = path.node;
+        path.stop();
+      }
+    },
+  });
+  return targetJSXElement;
 }
 
 /**

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -181,6 +181,7 @@ export interface IWorkspace {
   copySelectedNode: () => void;
   pasteSelectedNode: () => void;
   insertToSelectedNode: (childNameOrPrototype: string | ComponentPrototypeType) => void;
+  getSelectedNodePrototype: () => ComponentPrototypeType;
   dropNode: () => void;
   insertToNode: (
     targetNodeId: string,

--- a/packages/core/src/models/workspace.ts
+++ b/packages/core/src/models/workspace.ts
@@ -17,6 +17,7 @@ import {
   namesToImportDeclarations,
   getBlockNameByFilename,
   getPrivilegeCode,
+  jsxElemente2prototype,
 } from '../helpers';
 import { DropMethod } from './drop-target';
 import { HistoryMessage, TangoHistory } from './history';
@@ -1123,6 +1124,27 @@ export class Workspace extends EventTarget implements IWorkspace {
           [targetFile.filename]: targetFile.code,
         },
       });
+    }
+  }
+
+  /**
+   * 获取当前选中元素的prototype
+   * 默认从 componentPrototypes 中获取
+   * 获取失败则按照当前JSX的AST信息自动生成一份
+   * @returns prototype
+   */
+  getSelectedNodePrototype() {
+    if (this.selectSource.isSelected) {
+      const selectedNode = this.selectSource.first;
+      const presetPrototype = this.componentPrototypes.get(selectedNode.name);
+      if (presetPrototype) {
+        return presetPrototype;
+      }
+
+      if (this.selectSource.firstNode?.rawNode) {
+        const prototypes = jsxElemente2prototype(this.selectSource.firstNode.rawNode as JSXElement);
+        return prototypes;
+      }
     }
   }
 

--- a/packages/designer/src/dnd/use-dnd.ts
+++ b/packages/designer/src/dnd/use-dnd.ts
@@ -84,10 +84,10 @@ export function useDnd({
   const onMouseMove = (e: React.MouseEvent) => {
     const point = sandboxQuery.getRelativePoint({ x: e.clientX, y: e.clientY });
     setElementStyle('.SelectionMask', {
-      width: Math.abs(selectSource.start?.point.x - point.x) + 'px',
-      height: Math.abs(selectSource.start?.point.y - point.y) + 'px',
-      left: Math.min(selectSource.start?.point.x, point.x) + 'px',
-      top: Math.min(selectSource.start?.point.y, point.y) + 'px',
+      width: `${Math.abs(selectSource.start?.point.x - point.x)}px`,
+      height: `${Math.abs(selectSource.start?.point.y - point.y)}px`,
+      left: `${Math.min(selectSource.start?.point.x, point.x)}px`,
+      top: `${Math.min(selectSource.start?.point.y, point.y)}px`,
     });
   };
 

--- a/packages/designer/src/setting-panel.tsx
+++ b/packages/designer/src/setting-panel.tsx
@@ -73,7 +73,7 @@ export const SettingPanel = observer(({ title = '设置面板', ...props }: Sett
     },
   });
 
-  const prototype = workspace.componentPrototypes.get(workspace.selectSource.first?.name);
+  const prototype = workspace.getSelectedNodePrototype();
 
   return (
     <Panel

--- a/packages/designer/src/sidebar/outline-panel/components-tree.tsx
+++ b/packages/designer/src/sidebar/outline-panel/components-tree.tsx
@@ -172,11 +172,13 @@ export const ComponentsTree: React.FC<ComponentsTreeProps> = observer(
             const slotKey = keys?.[0] as string;
             const data = sandboxQuery.getDraggableParentsData(buildQueryBySlotId(slotKey), true);
             if (data && data.id) {
+              workspace.selectSource.select(data);
+            } else {
+              const d = parseDndId(slotKey);
               workspace.selectSource.select({
-                id: data.id,
-                name: data.name,
-                bounding: data.bounding,
-                parents: data.parents,
+                id: d.id,
+                name: d.component,
+                filename: d.filename,
               });
             }
             // export selected


### PR DESCRIPTION
fix
- 修复左侧大纲树选中节点未传filename, 右侧沙箱显示不在当前文件问题
- ![image](https://github.com/NetEase/tango/assets/25972237/8ded3f75-6eca-4a66-9a29-45255ed71b23)

feat
- 对未注册prototype的JSX节点，默认解析当前JSX属性，生成一份默认的prototype，避免显示找不到当前组件配置