### PR TITLE
Fix/enum setter

### DIFF
--- a/packages/designer/src/components/input-kv.tsx
+++ b/packages/designer/src/components/input-kv.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, memo } from 'react';
 import { Input } from 'antd';
 import { css, Box } from 'coral-system';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { ExpressionSetter } from '../setters/expression-setter';
 
 const rowCss = css`
   display: flex;
@@ -40,8 +41,36 @@ const tipCss = css`
   margin-bottom: 8px;
 `;
 
+const SCENE_COMPONENTS = {
+  default: ['input', 'input'],
+  params: ['input', 'expression'],
+};
+
+const InputComponent = ({ component, ...props }: any) => {
+  switch (component) {
+    case 'expression':
+      return (
+        <Box overflowX="auto" minWidth="45%">
+          <ExpressionSetter {...props} placeholder="请选择或输入Value" />
+        </Box>
+      );
+    default:
+      return (
+        <Input
+          style={{ minWidth: '45%' }}
+          allowClear
+          {...props}
+          onChange={(ev) => {
+            props.onChange(ev.target?.value);
+          }}
+        />
+      );
+  }
+};
+
 const OneInputKV = (props: any) => {
   const {
+    scene = 'default', // dafault｜params
     keyInputProps,
     valueInputProps,
     format = 'simple',
@@ -49,7 +78,7 @@ const OneInputKV = (props: any) => {
     defaultValue,
     value,
   } = props;
-  const [data, setData] = useState<Array<any> | any>(
+  const [data, setData] = useState<any[] | any>(
     formatValue({
       data: defaultValue || value,
       format: 'original',
@@ -123,22 +152,22 @@ const OneInputKV = (props: any) => {
     data?.map((item: any, index: number) => (
       <>
         <Box key={item.index} css={rowCss}>
-          <Input
-            allowClear
-            placeholder="请输入 Key"
+          <InputComponent
+            component={SCENE_COMPONENTS[scene][0]}
+            placeholder="请输入Key"
             {...keyInputProps}
             value={item.key}
-            onChange={(ev) => {
-              handleInput('key', index, ev.target?.value);
+            onChange={(val: any) => {
+              handleInput('key', index, val);
             }}
           />
-          <Input
-            allowClear
-            placeholder="请输入 Value"
+          <InputComponent
+            component={SCENE_COMPONENTS[scene][1]}
+            placeholder="请输入Value"
             {...valueInputProps}
             value={item.value}
-            onChange={(ev) => {
-              handleInput('value', index, ev.target.value);
+            onChange={(val: any) => {
+              handleInput('value', index, val);
             }}
           />
           <DeleteOutlined
@@ -198,8 +227,8 @@ const formatValue = ({ format, data }: IFormatValueConfig) => {
   }
 };
 
-const compareValue = (origin: Array<any>, data: Array<any>) => {
-  const resolve = (list: Array<any>) => {
+const compareValue = (origin: any[], data: any[]) => {
+  const resolve = (list: any[]) => {
     let keyStr = '';
     let valueStr = '';
 

--- a/packages/designer/src/components/input-kv.tsx
+++ b/packages/designer/src/components/input-kv.tsx
@@ -50,14 +50,14 @@ const InputComponent = ({ component, ...props }: any) => {
   switch (component) {
     case 'expression':
       return (
-        <Box overflowX="auto" minWidth="45%">
-          <ExpressionSetter {...props} placeholder="请选择或输入Value" />
+        <Box overflowX="auto" minWidth="60%">
+          <ExpressionSetter {...props} placeholder="value" />
         </Box>
       );
     default:
       return (
         <Input
-          style={{ minWidth: '45%' }}
+          style={{ minWidth: '30%' }}
           allowClear
           {...props}
           onChange={(ev) => {
@@ -154,7 +154,7 @@ const OneInputKV = (props: any) => {
         <Box key={item.index} css={rowCss}>
           <InputComponent
             component={SCENE_COMPONENTS[scene][0]}
-            placeholder="请输入Key"
+            placeholder="key"
             {...keyInputProps}
             value={item.key}
             onChange={(val: any) => {
@@ -163,7 +163,7 @@ const OneInputKV = (props: any) => {
           />
           <InputComponent
             component={SCENE_COMPONENTS[scene][1]}
-            placeholder="请输入Value"
+            placeholder="value"
             {...valueInputProps}
             value={item.value}
             onChange={(val: any) => {

--- a/packages/designer/src/setters/index.ts
+++ b/packages/designer/src/setters/index.ts
@@ -4,6 +4,7 @@ import { ColumnSetter } from './column-setter';
 import { CssSetter } from './css-setter';
 import { DateRangeSetter, DateSetter, TimeRangeSetter } from './date-setter';
 import { EnumSetter } from './enum-setter';
+import { TagEnumMapSetter } from './tag-enum-map-setter';
 import { EventSetter } from './event-setter';
 import { ExpressionSetter } from './expression-setter';
 import { JSONSetter } from './json-setter';
@@ -166,6 +167,7 @@ const setters: IFormItemCreateOptions[] = [
   },
   { name: 'bgSetter', component: BgSetter },
   { name: 'borderSetter', component: BorderSetter },
+  { name: 'tagEnumMapSetter', component: TagEnumMapSetter },
 ];
 
 export function registerBuiltinSetters() {

--- a/packages/designer/src/setters/render-props-setter.tsx
+++ b/packages/designer/src/setters/render-props-setter.tsx
@@ -70,20 +70,20 @@ const tableCellOptions: RenderSetterProps['options'] = [
   {
     label: '标签',
     value: 'Tag',
-    render: getRender('<Tag>tag</Tag>', 'tableCell'),
+    render: '{(value, record, index) => <Tag children={value} />}',
     relatedImports: ['Tag'],
+  },
+  {
+    label: '图片',
+    value: 'Image',
+    render: '{(value, record, index) => <Image width={150} src={value} />}',
+    relatedImports: ['Image'],
   },
   {
     label: '按钮',
     value: 'Button',
     render: getRender('<Button>button</Button>', 'tableCell'),
     relatedImports: ['Button'],
-  },
-  {
-    label: '图片',
-    value: 'Image',
-    render: getRender('<Image width={150} src="https://picsum.photos/100" />', 'tableCell'),
-    relatedImports: ['Image'],
   },
 ];
 

--- a/packages/designer/src/setters/tag-enum-map-setter.tsx
+++ b/packages/designer/src/setters/tag-enum-map-setter.tsx
@@ -8,7 +8,7 @@ import { Box, Text } from 'coral-system';
 const optionFormFields: NewOptionFormFieldType[] = [
   { label: 'value', name: 'value', required: true },
   { label: 'label', name: 'label', required: true },
-  { label: '颜色', name: 'color', component: <ColorSetter /> },
+  { label: '颜色', name: 'color', component: <ColorSetter onChange={() => {}} /> },
   {
     label: '状态',
     name: 'status',

--- a/packages/designer/src/setters/tag-enum-map-setter.tsx
+++ b/packages/designer/src/setters/tag-enum-map-setter.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { FormItemComponentProps } from '@music163/tango-setting-form';
+import { ListSetter, NewOptionFormFieldType } from './list-setter';
+import { ColorSetter } from './style-setter';
+import { Badge, Select } from 'antd';
+import { Box, Text } from 'coral-system';
+
+const optionFormFields: NewOptionFormFieldType[] = [
+  { label: 'value', name: 'value', required: true },
+  { label: 'label', name: 'label', required: true },
+  { label: '颜色', name: 'color', component: <ColorSetter /> },
+  {
+    label: '状态',
+    name: 'status',
+    extra: '设置了颜色，该配置失效',
+    component: (
+      <Select
+        allowClear
+        options={['success', 'processing', 'error', 'warning', 'default'].map((item) => ({
+          label: item,
+          value: item,
+        }))}
+      />
+    ),
+  },
+];
+
+const getKey = (item: any) => item.value;
+const renderItem = (item: any) => {
+  return (
+    <Box display="inline-flex" alignItems="center" gap="12px">
+      <Text>{`${item.value}：${item.label}`}</Text>
+      {item.color && (
+        <Box bg={item.color} border="solid" borderColor="gray.40" size="14px" borderRadius="s" />
+      )}
+      {!item.color && item.status && <Badge dot status={item.status} text={item.status} />}
+    </Box>
+  );
+};
+
+/**
+ * TagEnumMap设置器
+ */
+export function TagEnumMapSetter(props: FormItemComponentProps<any[]>) {
+  return (
+    <ListSetter
+      getListItemKey={getKey}
+      renderItem={renderItem}
+      listItemFormFields={optionFormFields}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
1. enumSetter的value支持传对象

<img width="317" alt="image" src="https://github.com/NetEase/tango/assets/21952641/31024e9e-976e-48d7-993d-27004a4111aa">

```jsx
{
  name: 'params',
  title: '参数',
  setter: 'enumSetter',
  setterProps: {
    scene: 'params'
  }
}
```

2. 新增tagEnumMapSetter

<img width="638" alt="image" src="https://github.com/NetEase/tango/assets/21952641/d8356ae5-90d0-4db3-81ff-6d942defd1ff">

```jsx
{
  name: 'enumMap',
  title: 'enumMap',
  setter: 'tagEnumMapSetter',
},
```


