### PR TITLE
feat: support add components with popover

### DIFF
--- a/apps/playground/src/helpers/mock-files.ts
+++ b/apps/playground/src/helpers/mock-files.ts
@@ -165,6 +165,7 @@ class App extends React.Component {
   render() {
     return (
       <Page title={tango.stores.app.title} subTitle={111}>
+        <Section tid="section0" />
         <Section tid="section1" title="Section Title">
           your input: <Input tid="input1" defaultValue="hello" />
           copy input: <Input value={tango.page.input1?.value} />
@@ -191,7 +192,7 @@ class App extends React.Component {
         </Section>
         <Section title="原生 DOM" tid="section4">
           <h1 style={{ ...{ color: "red" }, fontSize: 64 }}>
-          hello world
+            hello world
           </h1>
           <div
             style={{

--- a/apps/playground/src/helpers/prototypes.ts
+++ b/apps/playground/src/helpers/prototypes.ts
@@ -45,14 +45,18 @@ const Snippet2ColumnLayout: IComponentPrototype = {
 const Snippet3ColumnLayout: IComponentPrototype = {
   name: 'Snippet3ColumnLayout',
   title: '三列布局',
-  icon: 'icon-column3',
+  icon: 'icon-column-3',
   type: 'snippet',
   package: '@music163/antd',
+  // FIXME: Column 组件 需要更新为 defineComponent
   initChildren: `
   <Columns columns={12}>
-    <Column colSpan={4}></Column>
-    <Column colSpan={4}></Column>
-    <Column colSpan={4}></Column>
+    <Column colSpan={4}>
+    </Column>
+    <Column colSpan={4}>
+    </Column>
+    <Column colSpan={4}>
+  </Column>
   </Columns>
   `,
   relatedImports: ['Columns', 'Column'],
@@ -76,13 +80,9 @@ const SnippetButtonGroup: IComponentPrototype = {
 // hack some prototypes
 basePrototypes['Section'].siblingNames = [
   'SnippetButtonGroup',
-  'Section',
-  'Section',
-  'Section',
-  'Section',
-  'Section',
-  'Section',
-  'Section',
+  'Snippet2ColumnLayout',
+  'Snippet3ColumnLayout',
+  'SnippetSuccessResult',
 ];
 
 export const nativeDomPrototypes = () => {

--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -28,34 +28,6 @@ import {
 import { Action } from '@music163/tango-ui';
 import { useState } from 'react';
 
-// 1. 实例化工作区
-const workspace = new Workspace({
-  entry: '/src/index.js',
-  files: sampleFiles,
-  prototypes,
-});
-
-// inject workspace to window for debug
-(window as any).__workspace__ = workspace;
-
-// 2. 引擎初始化
-const engine = createEngine({
-  workspace,
-});
-
-// @ts-ignore
-window.__workspace__ = workspace;
-
-// 3. 沙箱初始化
-const sandboxQuery = new DndQuery({
-  context: 'iframe',
-});
-
-// 4. 图标库初始化（物料面板和组件树使用了 iconfont 里的图标）
-createFromIconfontCN({
-  scriptUrl: '//at.alicdn.com/t/c/font_2891794_6d4hj5u0bjx.js',
-});
-
 const menuData = {
   common: [
     {
@@ -89,6 +61,35 @@ const menuData = {
     },
   ],
 };
+
+// 1. 实例化工作区
+const workspace = new Workspace({
+  entry: '/src/index.js',
+  files: sampleFiles,
+  prototypes,
+});
+
+// inject workspace to window for debug
+(window as any).__workspace__ = workspace;
+
+// 2. 引擎初始化
+const engine = createEngine({
+  workspace,
+  menuData,
+});
+
+// @ts-ignore
+window.__workspace__ = workspace;
+
+// 3. 沙箱初始化
+const sandboxQuery = new DndQuery({
+  context: 'iframe',
+});
+
+// 4. 图标库初始化（物料面板和组件树使用了 iconfont 里的图标）
+createFromIconfontCN({
+  scriptUrl: '//at.alicdn.com/t/c/font_2891794_6d4hj5u0bjx.js',
+});
 
 /**
  * 5. 平台初始化，访问 https://local.netease.com:6006/

--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -88,7 +88,7 @@ const sandboxQuery = new DndQuery({
 
 // 4. 图标库初始化（物料面板和组件树使用了 iconfont 里的图标）
 createFromIconfontCN({
-  scriptUrl: '//at.alicdn.com/t/c/font_2891794_6d4hj5u0bjx.js',
+  scriptUrl: '//at.alicdn.com/t/c/font_2891794_cxbtmzehxyi.js',
 });
 
 /**

--- a/apps/playground/src/pages/mail.tsx
+++ b/apps/playground/src/pages/mail.tsx
@@ -45,7 +45,7 @@ const sandboxQuery = new DndQuery({
 
 // 4. 图标库初始化（物料面板和组件树使用了 iconfont 里的图标）
 createFromIconfontCN({
-  scriptUrl: '//at.alicdn.com/t/c/font_2891794_cou9i7556tl.js',
+  scriptUrl: '//at.alicdn.com/t/c/font_2891794_cxbtmzehxyi.js',
 });
 
 /**
@@ -112,6 +112,7 @@ export default function App() {
                   if (sandboxWindow.TangoMail) {
                     if (sandboxWindow.TangoMail.menuData) {
                       setMenuData(sandboxWindow.TangoMail.menuData);
+                      engine.designer.setMenuData(sandboxWindow.TangoMail.menuData);
                     }
                     if (sandboxWindow.TangoMail.prototypes) {
                       workspace.setComponentPrototypes(sandboxWindow.TangoMail.prototypes);

--- a/apps/storybook/src/setting-form.stories.tsx
+++ b/apps/storybook/src/setting-form.stories.tsx
@@ -14,7 +14,7 @@ const BLACK_LIST = ['codeSetter', 'eventSetter', 'modelSetter', 'routerSetter'];
 BUILT_IN_SETTERS.filter((setter) => !BLACK_LIST.includes(setter.name)).forEach(register);
 
 createFromIconfontCN({
-  scriptUrl: '//at.alicdn.com/t/c/font_2891794_cou9i7556tl.js',
+  scriptUrl: '//at.alicdn.com/t/c/font_2891794_cxbtmzehxyi.js',
 });
 
 export default {

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,3 +1,4 @@
+import { MenuDataType } from '@music163/tango-helpers';
 import { Designer, Engine, SimulatorNameType } from './models';
 import { IWorkspace } from './models/interfaces';
 
@@ -6,6 +7,10 @@ interface ICreateEngineOptions {
    * 自定义工作区
    */
   workspace?: IWorkspace;
+  /**
+   * 菜单信息
+   */
+  menuData?: MenuDataType;
   /**
    * 默认的模拟器模式
    */
@@ -25,6 +30,7 @@ export function createEngine({
   workspace,
   defaultSimulatorMode = 'desktop',
   defaultActiveSidebarPanel = '',
+  menuData,
 }: ICreateEngineOptions) {
   const engine = new Engine({
     workspace,
@@ -32,6 +38,7 @@ export function createEngine({
       workspace,
       simulator: defaultSimulatorMode,
       activeSidebarPanel: defaultActiveSidebarPanel,
+      menuData,
     }),
   });
 

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -92,7 +92,7 @@ export class Designer {
   /**
    * 菜单列表
    */
-  _menuData?: MenuDataType;
+  _menuData?: MenuDataType = null;
 
   private readonly workspace: IWorkspace;
 

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -1,5 +1,6 @@
 import { action, computed, makeObservable, observable, toJS } from 'mobx';
 import { IWorkspace } from './interfaces';
+import { MenuDataType } from '@music163/tango-helpers';
 
 export type SimulatorNameType = 'desktop' | 'phone';
 
@@ -19,6 +20,10 @@ interface IViewportBounding {
 interface IDesignerOptions {
   workspace: IWorkspace;
   simulator?: SimulatorNameType | ISimulatorType;
+  /**
+   * 菜单配置
+   */
+  menuData: MenuDataType;
   activeSidebarPanel?: string;
 }
 
@@ -65,6 +70,16 @@ export class Designer {
   _showSmartWizard = false;
 
   /**
+   * 是否显示添加组件面板
+   */
+  _showAddComponentPopover = false;
+
+  /**
+   * 添加组件面板的位置
+   */
+  _addComponentPopoverPosition = { clientX: 0, clientY: 0 };
+
+  /**
    * 是否显示右侧面板
    */
   _showRightPanel = true;
@@ -75,9 +90,9 @@ export class Designer {
   _isPreview = false;
 
   /**
-   * 默认展开的侧边栏
+   * 菜单列表
    */
-  defaultActiveSidebarPanel?: string;
+  _menuData?: MenuDataType;
 
   private readonly workspace: IWorkspace;
 
@@ -109,10 +124,26 @@ export class Designer {
     return this._showRightPanel;
   }
 
+  get showAddComponentPopover() {
+    return this._showAddComponentPopover;
+  }
+
+  get addComponentPopoverPosition() {
+    return this._addComponentPopoverPosition;
+  }
+
+  get menuData() {
+    return this._menuData ?? ([] as MenuDataType);
+  }
+
   constructor(options: IDesignerOptions) {
     this.workspace = options.workspace;
 
-    const { simulator, activeSidebarPanel: defaultActiveSidebarPanel } = options;
+    const { simulator, menuData, activeSidebarPanel: defaultActiveSidebarPanel } = options;
+
+    if (menuData) {
+      this.setMenuData(menuData);
+    }
 
     // 默认设计器模式
     if (simulator) {
@@ -131,6 +162,9 @@ export class Designer {
       _activeSidebarPanel: observable,
       _showSmartWizard: observable,
       _showRightPanel: observable,
+      _showAddComponentPopover: observable,
+      _addComponentPopoverPosition: observable,
+      _menuData: observable,
       _isPreview: observable,
       simulator: computed,
       viewport: computed,
@@ -139,6 +173,9 @@ export class Designer {
       isPreview: computed,
       showRightPanel: computed,
       showSmartWizard: computed,
+      showAddComponentPopover: computed,
+      addComponentPopoverPosition: computed,
+      menuData: computed,
       setSimulator: action,
       setViewport: action,
       setActiveView: action,
@@ -147,6 +184,7 @@ export class Designer {
       toggleRightPanel: action,
       toggleSmartWizard: action,
       toggleIsPreview: action,
+      toggleAddComponentPopover: action,
     });
   }
 
@@ -173,6 +211,11 @@ export class Designer {
       this._activeSidebarPanel = '';
     }
   }
+
+  setMenuData(menuData: MenuDataType) {
+    this._menuData = menuData;
+  }
+
   closeSidebarPanel() {
     this._activeSidebarPanel = '';
   }
@@ -183,6 +226,22 @@ export class Designer {
 
   toggleRightPanel(value?: boolean) {
     this._showRightPanel = value ?? !this._showRightPanel;
+  }
+
+  /**
+   * 显示添加组件面板
+   * @param value 是否显示
+   * @param position 坐标
+   */
+  toggleAddComponentPopover(
+    value: boolean,
+    position: {
+      clientX: number;
+      clientY: number;
+    } = this.addComponentPopoverPosition,
+  ) {
+    this._showAddComponentPopover = value;
+    this._addComponentPopoverPosition = position;
   }
 
   toggleIsPreview(value: boolean) {

--- a/packages/designer/src/components/components-popover.tsx
+++ b/packages/designer/src/components/components-popover.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Box } from 'coral-system';
+import { observer, useDesigner, useWorkspace } from '@music163/tango-context';
+import { IconFont, DragPanel } from '@music163/tango-ui';
+import { ComponentsPanel, ComponentsPanelProps } from '../sidebar';
+import { IComponentPrototype } from '@music163/tango-helpers';
+
+interface ComponentsPopoverProps {
+  // 添加组件位置
+  type?: 'inner' | 'before' | 'after';
+  // 弹出方式 手动触发/DOM 触发
+  isControlled?: boolean;
+  title?: string;
+  prototype?: IComponentPrototype;
+  children?: React.ReactNode;
+}
+
+export const ComponentsPopover = observer(
+  ({
+    type = 'inner',
+    title = '添加组件',
+    isControlled = false,
+    children,
+    ...popoverProps
+  }: ComponentsPopoverProps) => {
+    const [layout, setLayout] = useState<ComponentsPanelProps['layout']>('grid');
+    const workspace = useWorkspace();
+    const designer = useDesigner();
+
+    const { addComponentPopoverPosition, showAddComponentPopover } = designer;
+    const selectedNode = workspace.selectSource.selected?.[0];
+    const selectedNodeId = selectedNode?.codeId ?? '未选中';
+    const prototype =
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      workspace.componentPrototypes.get(selectedNode?.name) ?? ({} as IComponentPrototype);
+
+    // 推荐使用的子组件
+    const insertedList = useMemo(
+      () =>
+        Array.isArray(prototype?.childrenName)
+          ? prototype?.childrenName
+          : [prototype?.childrenName].filter(Boolean),
+      [prototype?.childrenName],
+    );
+
+    // 推荐使用的代码片段
+    const siblingList = useMemo(() => prototype?.siblingNames ?? [], [prototype.siblingNames]);
+
+    const tipsTextMap = useMemo(
+      () => ({
+        before: `点击，在 ${selectedNodeId} 的前方添加节点`,
+        after: `点击，在 ${selectedNodeId} 的后方添加节点`,
+        inner: `点击，在 ${selectedNodeId} 内部添加节点`,
+      }),
+      [selectedNodeId],
+    );
+
+    const handleSelect = useCallback(
+      (name: string) => {
+        switch (type) {
+          case 'before':
+            workspace.insertBeforeSelectedNode(name);
+            break;
+          case 'after':
+            workspace.insertAfterSelectedNode(name);
+            break;
+          case 'inner':
+            workspace.insertToSelectedNode(name);
+            break;
+          default:
+            break;
+        }
+      },
+      [type, workspace],
+    );
+
+    const changeLayout = useCallback(() => {
+      setLayout(layout === 'grid' ? 'line' : 'grid');
+    }, [layout]);
+
+    const menuData = useMemo(() => {
+      const menuList = JSON.parse(JSON.stringify(designer.menuData));
+
+      const commonList = menuList['common'] ?? [];
+      if (commonList?.length && siblingList?.length) {
+        commonList.unshift({
+          title: '代码片段',
+          items: siblingList,
+        });
+      }
+
+      if (commonList?.length && insertedList?.length) {
+        commonList.unshift({
+          title: '推荐使用',
+          items: insertedList,
+        });
+      }
+
+      return menuList;
+    }, [insertedList, siblingList, designer.menuData]);
+
+    const innerTypeProps =
+      // 手动触发 适用于 点击添加组件
+      type === 'inner' && isControlled
+        ? {
+            open: showAddComponentPopover,
+            onOpenChange: (open: boolean) => designer.toggleAddComponentPopover(open),
+            left: addComponentPopoverPosition.clientX,
+            top: addComponentPopoverPosition.clientY,
+          }
+        : {};
+
+    return (
+      <DragPanel
+        {...innerTypeProps}
+        title={title}
+        extra={
+          <Box fontSize="12px">
+            {layout === 'grid' ? (
+              <IconFont type="icon-liebiaoitem" onClick={changeLayout} />
+            ) : (
+              <IconFont type="icon-grid1" onClick={changeLayout} />
+            )}
+          </Box>
+        }
+        footer={tipsTextMap[type]}
+        width="330px"
+        maskClosable
+        body={
+          <ComponentsPanel
+            isScope
+            showBizComps={false}
+            menuData={menuData}
+            layout={layout}
+            onItemSelect={handleSelect}
+            style={{
+              maxHeight: '400px',
+              overflow: 'auto',
+            }}
+          />
+        }
+        {...popoverProps}
+      >
+        {children}
+      </DragPanel>
+    );
+  },
+);

--- a/packages/designer/src/components/index.ts
+++ b/packages/designer/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './drag-box';
 export * from './input-kv';
 export * from './variable-tree';
 export * from './variable-tree-modal';
+export * from './components-popover';

--- a/packages/designer/src/dnd/use-dnd.ts
+++ b/packages/designer/src/dnd/use-dnd.ts
@@ -84,10 +84,10 @@ export function useDnd({
   const onMouseMove = (e: React.MouseEvent) => {
     const point = sandboxQuery.getRelativePoint({ x: e.clientX, y: e.clientY });
     setElementStyle('.SelectionMask', {
-      width: Math.abs(selectSource.start?.point.x - point.x) + 'px',
-      height: Math.abs(selectSource.start?.point.y - point.y) + 'px',
-      left: Math.min(selectSource.start?.point.x, point.x) + 'px',
-      top: Math.min(selectSource.start?.point.y, point.y) + 'px',
+      width: `${Math.abs(selectSource.start?.point.x - point.x)}px`,
+      height: `${Math.abs(selectSource.start?.point.y - point.y)}px`,
+      left: `${Math.min(selectSource.start?.point.x, point.x)}px`,
+      top: `${Math.min(selectSource.start?.point.y, point.y)}px`,
     });
   };
 
@@ -405,6 +405,13 @@ export function useDnd({
 
         // 打开智能向导弹窗
         designer.toggleSmartWizard(true);
+        break;
+      case 'addComponent':
+        // 打开添加组件面板
+        designer.toggleAddComponentPopover(true, {
+          clientX: (e.detail.meta as any).clientX + 40,
+          clientY: (e.detail.meta as any).clientY + 110,
+        });
         break;
       default:
         break;

--- a/packages/designer/src/sidebar/components-panel.tsx
+++ b/packages/designer/src/sidebar/components-panel.tsx
@@ -17,7 +17,6 @@ import { getDragGhostElement } from '../helpers';
 
 type IComponentsPanelContext = {
   isScope: boolean;
-  isCollapsed: boolean;
   onItemSelect: (name: string) => void;
   layout: 'grid' | 'line';
 };
@@ -49,10 +48,6 @@ export interface ComponentsPanelProps {
    * 是否局部模式 (快捷添加组件面板中使用)
    */
   isScope?: boolean;
-  /**
-   * 是否折叠
-   */
-  isCollapsed?: boolean;
   /**
    * 组件选中回调
    */
@@ -106,7 +101,6 @@ export function useFlatMenuData<T>(menuData: T) {
 export const ComponentsPanel = observer(
   ({
     isScope = false,
-    isCollapsed = true,
     menuData = emptyMenuData,
     showBizComps = true,
     getBizCompName = upperCamelCase,
@@ -166,7 +160,6 @@ export const ComponentsPanel = observer(
     return (
       <ComponentsPanelProvider
         value={{
-          isCollapsed,
           isScope,
           onItemSelect,
           layout,
@@ -208,7 +201,7 @@ interface MaterialListProps {
 
 function MaterialList({ data, filterKeyword, type = 'common' }: MaterialListProps) {
   const workspace = useWorkspace();
-  const { isCollapsed, layout } = usePanelContext();
+  const { layout } = usePanelContext();
   const isGrid = layout === 'grid';
 
   return (
@@ -231,7 +224,6 @@ function MaterialList({ data, filterKeyword, type = 'common' }: MaterialListProp
               title={cate.title}
               borderBottom="solid"
               borderColor="line.normal"
-              isCollapsed={isCollapsed}
               showBottomBorder={false}
               bodyProps={{
                 padding: isGrid ? '4px 12px 12px' : '0',

--- a/packages/designer/src/sidebar/sidebar.tsx
+++ b/packages/designer/src/sidebar/sidebar.tsx
@@ -74,7 +74,7 @@ export interface SidebarPanelItemProps
   widgetProps?: object;
 }
 
-function BaseSidebarPanel({ panelWidth: defaultPanelWidth = 280, footer, children }: SidebarProps) {
+function BaseSidebarPanel({ panelWidth: defaultPanelWidth = 266, footer, children }: SidebarProps) {
   const designer = useDesigner();
 
   const items = useMemo(() => {

--- a/packages/designer/src/workspace-view.tsx
+++ b/packages/designer/src/workspace-view.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box } from 'coral-system';
 import { observer, useDesigner } from '@music163/tango-context';
 import { DesignerViewType } from '@music163/tango-core';
+import { ComponentsPopover } from './components';
 
 export interface WorkspaceViewProps {
   /**
@@ -27,6 +28,8 @@ export const WorkspaceView = observer((props: WorkspaceViewProps) => {
       position="relative"
     >
       {children}
+      {/* 添加组件弹层 */}
+      {display === 'block' && <ComponentsPopover type="inner" isControlled />}
     </Box>
   );
 });

--- a/packages/helpers/src/types/prototype.ts
+++ b/packages/helpers/src/types/prototype.ts
@@ -3,6 +3,7 @@
  */
 
 import { OptionType } from './advanced';
+import { PartialRecord } from './base';
 
 /**
  * @deprecated 请使用 IComponentProp 代替
@@ -327,3 +328,19 @@ export interface ITangoConfigJson {
     autoGenerateComponentId: boolean;
   };
 }
+
+/**
+ * 物料类型
+  common: '基础组件',
+  atom: '原子组件',
+  snippet: '组合',
+  bizComp: '业务组件',
+  localComp: '本地组件',
+ */
+export type MenuKeyType = 'common' | 'atom' | 'snippet' | 'bizComp' | 'localComp';
+export type MenuValueType = Array<{ title: string; items: string[] }>;
+
+/**
+ * 菜单项类型
+ */
+export type MenuDataType = PartialRecord<MenuKeyType, MenuValueType>;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,8 @@
     "coral-system": "^1.0.5",
     "eslint-linter-browserify": "^8.51.0",
     "react-json-view": "^1.21.3",
-    "react-monaco-editor-lite": "^1.3.9"
+    "react-monaco-editor-lite": "^1.3.11",
+    "react-draggable": "^4.4.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ui/src/collapse-panel.tsx
+++ b/packages/ui/src/collapse-panel.tsx
@@ -5,6 +5,10 @@ import { useControllableState } from '@music163/tango-helpers';
 
 export interface CollapsePanelProps extends Omit<HTMLCoralProps<'div'>, 'title'> {
   /**
+   * 是否折叠
+   */
+  isCollapsed?: boolean;
+  /**
    * 标题
    */
   title?: React.ReactNode;
@@ -48,6 +52,7 @@ const headerStyle = css`
 
 export function CollapsePanel(props: CollapsePanelProps) {
   const {
+    isCollapsed = true,
     title,
     extra,
     children,
@@ -84,7 +89,9 @@ export function CollapsePanel(props: CollapsePanelProps) {
         borderBottom: 'solid',
         borderBottomColor: 'line2',
       }
-    : {};
+    : {
+        border: 'none!important',
+      };
 
   return (
     <Box className="CollapsePanel" {...CollapsePanelBorderStyle} {...rest}>
@@ -93,14 +100,16 @@ export function CollapsePanel(props: CollapsePanelProps) {
         alignItems="center"
         justifyContent="space-between"
         className="CollapsePanelHeader"
-        onClick={() => setCollapsed(!collapsed)}
-        p="m"
+        onClick={() => isCollapsed && setCollapsed(!collapsed)}
+        p="l"
+        paddingTop={'m'}
+        paddingBottom={'m'}
         {...stickHeaderProps}
         {...headerProps}
         css={headerStyle}
       >
         <Box display="flex" alignItems="center" fontSize="14px" fontWeight="500">
-          <UpOutlined style={iconStyle} />
+          {isCollapsed && <UpOutlined style={iconStyle} />}
           {title}
         </Box>
         <Box>{extra}</Box>

--- a/packages/ui/src/collapse-panel.tsx
+++ b/packages/ui/src/collapse-panel.tsx
@@ -5,10 +5,6 @@ import { useControllableState } from '@music163/tango-helpers';
 
 export interface CollapsePanelProps extends Omit<HTMLCoralProps<'div'>, 'title'> {
   /**
-   * 是否折叠
-   */
-  isCollapsed?: boolean;
-  /**
    * 标题
    */
   title?: React.ReactNode;
@@ -52,7 +48,6 @@ const headerStyle = css`
 
 export function CollapsePanel(props: CollapsePanelProps) {
   const {
-    isCollapsed = true,
     title,
     extra,
     children,
@@ -100,7 +95,7 @@ export function CollapsePanel(props: CollapsePanelProps) {
         alignItems="center"
         justifyContent="space-between"
         className="CollapsePanelHeader"
-        onClick={() => isCollapsed && setCollapsed(!collapsed)}
+        onClick={() => setCollapsed(!collapsed)}
         p="l"
         paddingTop={'m'}
         paddingBottom={'m'}
@@ -109,7 +104,7 @@ export function CollapsePanel(props: CollapsePanelProps) {
         css={headerStyle}
       >
         <Box display="flex" alignItems="center" fontSize="14px" fontWeight="500">
-          {isCollapsed && <UpOutlined style={iconStyle} />}
+          <UpOutlined style={iconStyle} />
           {title}
         </Box>
         <Box>{extra}</Box>

--- a/packages/ui/src/drag-panel.tsx
+++ b/packages/ui/src/drag-panel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Text, styled } from 'coral-system';
-import { Popover, PopoverProps, IconFont } from '../lib/esm';
+import { Popover, PopoverProps, IconFont } from './';
 import Draggable from 'react-draggable';
 import { CloseOutlined } from '@ant-design/icons';
 import { noop } from '@music163/tango-helpers';

--- a/packages/ui/src/drag-panel.tsx
+++ b/packages/ui/src/drag-panel.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Box, Text, styled } from 'coral-system';
+import { Popover, PopoverProps, IconFont } from '../lib/esm';
+import Draggable from 'react-draggable';
+import { CloseOutlined } from '@ant-design/icons';
+import { noop } from '@music163/tango-helpers';
+
+const CloseIcon = styled(CloseOutlined)`
+  cursor: pointer;
+  margin-left: 10px;
+  padding: 2px;
+  font-size: 13px;
+  &:hover {
+    color: var(--tango-colors-text1);
+    background-color: var(--tango-colors-line1);
+    border-radius: 4px;
+  }
+`;
+
+interface DragPanelProps extends Omit<PopoverProps, 'overlay'> {
+  // 标题
+  title?: React.ReactNode | string;
+  // 内容
+  body?: React.ReactNode | string;
+  // 底部
+  footer?: ((close: () => void) => React.ReactNode) | React.ReactNode | string;
+  // 宽度
+  width?: number | string;
+  // 右上角区域
+  extra?: React.ReactNode | string;
+  children?: React.ReactNode;
+}
+
+export function DragPanel({
+  title,
+  footer,
+  body,
+  children,
+  width = 330,
+  extra,
+  onOpenChange = noop,
+  ...props
+}: DragPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  const footerNode =
+    typeof footer === 'function'
+      ? footer(() => {
+          setOpen(false);
+          onOpenChange(false);
+        })
+      : footer;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(innerOpen) => {
+        setOpen(innerOpen);
+        onOpenChange(innerOpen);
+      }}
+      overlay={
+        <Draggable handle=".selection-drag-bar">
+          <Box
+            bg="#FFF"
+            borderRadius="m"
+            boxShadow="lowDown"
+            border="solid"
+            borderColor="line2"
+            overflow="hidden"
+            width={width}
+          >
+            {/* 头部区域 */}
+            <Box
+              px="l"
+              py="m"
+              className="selection-drag-bar"
+              borderBottom="1px solid var(--tango-colors-line2)"
+              cursor="move"
+              display="flex"
+              justifyContent="space-between"
+            >
+              <Box fontSize="12px" color="text2">
+                <IconFont type="icon-applications" />
+                <Text marginLeft={'5px'}>{title}</Text>
+              </Box>
+              <Box color="text2" fontSize="12px" display="flex" alignItems="center">
+                {extra}
+                <CloseIcon
+                  onClick={() => {
+                    setOpen(false);
+                    onOpenChange(false);
+                  }}
+                />
+              </Box>
+            </Box>
+            {/* 主体区域 */}
+            {body}
+            {/* 底部 */}
+            {footer && (
+              <Box
+                px="l"
+                py="m"
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                background="var(--tango-colors-line1)"
+                fontSize="12px"
+                fontWeight={400}
+                borderTop="1px solid var(--tango-colors-line2)"
+              >
+                {footerNode}
+              </Box>
+            )}
+          </Box>
+        </Draggable>
+      }
+      {...props}
+    >
+      {children}
+    </Popover>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,3 +22,5 @@ export * from './tabs';
 export * from './select-action';
 export * from './copy-clipboard';
 export * from './tag-select';
+export * from './popover';
+export * from './drag-panel';

--- a/packages/ui/src/popover.tsx
+++ b/packages/ui/src/popover.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { noop } from '@music163/tango-helpers';
+import { Box } from 'coral-system';
+
+export interface PopoverProps {
+  open?: boolean;
+  /**
+   * 浮层内容
+   */
+  overlay: React.ReactNode;
+  /**
+   * 浮层打开或关闭时的回调
+   */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * 浮层被遮挡时自动调整位置
+   */
+  autoAdjustOverflow?: boolean;
+  /**
+   * 点击蒙层是否允许关闭
+   */
+  maskClosable?: boolean;
+  /**
+   * 手动唤起时的位置
+   */
+  left?: number;
+  /**
+   * 手动唤起时的位置
+   */
+  top?: number;
+  /**
+   * z-index
+   */
+  zIndex?: number;
+  /**
+   * popoverStyle
+   */
+  popoverStyle?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+export const Popover: React.FC<PopoverProps> = ({
+  open,
+  overlay,
+  maskClosable = false,
+  autoAdjustOverflow = true,
+  left: controlledLeft,
+  top: controlledTop,
+  children,
+  popoverStyle,
+  onOpenChange = noop,
+  zIndex = 9999,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const [left, setLeft] = useState(0);
+  const [top, setTop] = useState(0);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // 唤起位置受控
+  const isControlledPostion = useMemo(
+    () => controlledLeft !== undefined || controlledTop !== undefined,
+    [controlledLeft, controlledTop],
+  );
+
+  useEffect(() => {
+    if (typeof controlledTop === 'number') {
+      setTop(controlledTop);
+    }
+    if (typeof controlledLeft === 'number') {
+      setLeft(controlledLeft);
+    }
+  }, [controlledTop, controlledLeft]);
+
+  useLayoutEffect(() => {
+    const handleDocumentClick = (e: MouseEvent) => {
+      if (
+        maskClosable &&
+        visible &&
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
+        setVisible(false);
+        onOpenChange(false);
+      }
+    };
+
+    if (maskClosable && visible) {
+      document.addEventListener('click', handleDocumentClick, true);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleDocumentClick);
+    };
+  }, [maskClosable, onOpenChange, visible]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const x = e.clientX;
+      const y = e.clientY;
+      setLeft(x);
+      setTop(y + 10);
+      setVisible(true);
+      onOpenChange(true);
+    },
+    [onOpenChange],
+  );
+
+  useEffect(() => {
+    setVisible(open);
+  }, [open]);
+
+  const getAdjustedPosition = () => {
+    const popoverElement = popoverRef.current;
+    if (popoverElement) {
+      const popoverRect = popoverElement.getBoundingClientRect();
+      if (popoverRect.right > window.innerWidth) {
+        setLeft(window.innerWidth - popoverRect.width);
+      }
+      if (popoverRect.bottom > window.innerHeight) {
+        setTop(window.innerHeight - popoverRect.height);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (visible && autoAdjustOverflow) {
+      getAdjustedPosition();
+    }
+  }, [visible, autoAdjustOverflow]);
+
+  const overlayStyle: React.CSSProperties = useMemo(
+    () => ({
+      display: visible ? 'block' : 'none',
+      position: 'fixed',
+      left,
+      top,
+      zIndex,
+      ...popoverStyle,
+    }),
+    [left, popoverStyle, top, visible, zIndex],
+  );
+
+  const overlayDom = (
+    <Box className="popover">
+      <Box ref={popoverRef} className="overlay" style={overlayStyle}>
+        {overlay}
+      </Box>
+    </Box>
+  );
+
+  return (
+    <>
+      {!isControlledPostion &&
+        React.cloneElement(children as any, {
+          onClick: (e: React.MouseEvent) => {
+            e.stopPropagation();
+            handleClick(e);
+            (children as any).props?.onClick?.(e);
+          },
+        })}
+      {visible ? ReactDOM.createPortal(overlayDom, document.body) : null}
+    </>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16101,7 +16101,7 @@ react-dom@^17.0.0:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-draggable@^4.0.3:
+react-draggable@^4.0.3, react-draggable@^4.4.5:
   version "4.4.6"
   resolved "https://registry.npmmirror.com/react-draggable/-/react-draggable-4.4.6.tgz"
   integrity sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==
@@ -16195,10 +16195,10 @@ react-merge-refs@^1.1.0:
   resolved "https://registry.npmmirror.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-monaco-editor-lite@^1.3.9:
-  version "1.3.9"
-  resolved "https://registry.npmmirror.com/react-monaco-editor-lite/-/react-monaco-editor-lite-1.3.9.tgz#377a2126f2a26de7e478323c70b13a50f0c5c760"
-  integrity sha512-pE6CydX/kkisHArbV8GE+TvhukIiT9YYUYBq/cnDL7tfwhX/h1tKQKMJwItnkJvjozaB5uS+oK77GWV874figQ==
+react-monaco-editor-lite@^1.3.11:
+  version "1.3.11"
+  resolved "https://registry.npmmirror.com/react-monaco-editor-lite/-/react-monaco-editor-lite-1.3.11.tgz#b81b681d23f3ca46f54d4e01f13781bcff6a4a03"
+  integrity sha512-+9xlIn98Yp2hD8OFjRNpQiBx+wLFzsvvT5EgNTxReFrDhFAPPjivdLUCiex1ktzpkGTdo3fxDFUokckvO7hVvQ==
   dependencies:
     monaco-editor "^0.38.0"
     monaco-editor-textmate "^4.0.0"
@@ -17697,16 +17697,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17819,7 +17810,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17832,13 +17823,6 @@ strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -19376,7 +19360,7 @@ workerpool@^9.1.1:
   resolved "https://registry.npmmirror.com/workerpool/-/workerpool-9.1.1.tgz#9ba4d534a79a5517c1e1b9d1014151516829be8d"
   integrity sha512-EFoFTSEo9m4V4wNrwzVRjxnf/E/oBpOzcI/R5CIugJhl9RsCiq525rszo4AtqcjQQoqFdu2E3H82AnbtpaQHvg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19389,15 +19373,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# 基础组件库 
https://github.com/NetEase/tango-components/pull/6
- tango-event-button & addComponent event
- Columns & Column 组件 add defineComponent HOC

# 设计器/引擎
## Feat
### Core
``` js
// designer 新增 menuData 属性
const engine = createEngine({
  workspace,
  menuData: 'design'
});
```

### 组件 UI & 添加组件重构
- 组件侧边栏面板 UI 2.0 (样式调整，自适应宽度)
- 新增 ComponentsPopover 组件
- 画布支持快捷添加子组件 & 兄弟组件
  - prototype.hasChildren !== false 默认显示添加子元素按钮
  - prototype.childrenName & prototype.siblingNames 声明为 推荐组件 / 代码片段 (默认显示在基础组件顶部)
![image](https://github.com/NetEase/tango/assets/25972237/42a8dbac-057f-4785-a0dc-046e91e35119)


### IconFont 新增图标
add 2 icons
```js
// newUrl
at.alicdn.com/t/c/font_2891794_cxbtmzehxyi.js
```

### WBEIDE
- 升级至 1.3.11

# UI Component
- Popover
- DragPanel
```typescript
interface DragPanelProps extends PopoverProps {
  // 标题
  title?: React.ReactNode | string;
  // 内容
  body?: React.ReactNode | string;
  // 底部
  footer?: ((close: () => void) => React.ReactNode) | React.ReactNode | string;
  // 宽度
  width?: number | string;
  // 右上角区域
  extra?: React.ReactNode | string;
}
```
```js
<DragPanel
  title="标题"
  extra="右上角内容"
  width={700}
  body={
    <Box>
      内容
    </Box>
  }
  footer={
    <Text>
      底部信息
    </Text>
  }
>
  <Action tooltip="打开表达式变量选择面板" icon={<ExpandAltOutlined />} size="small" />
</DragPanel>
```