### PR TITLE
feat: supoort set default active view

### DIFF
--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -41,6 +41,7 @@ const workspace = new Workspace({
 // 2. 引擎初始化
 const engine = createEngine({
   workspace,
+  defaultActiveView: 'design', // dual code design
 });
 
 // @ts-ignore

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,4 +1,4 @@
-import { Designer, Engine, SimulatorNameType } from './models';
+import { Designer, DesignerViewType, Engine, SimulatorNameType } from './models';
 import { IWorkspace } from './models/interfaces';
 
 interface ICreateEngineOptions {
@@ -14,6 +14,10 @@ interface ICreateEngineOptions {
    * 默认激活的侧边栏
    */
   defaultActiveSidebarPanel?: string;
+  /**
+   * 默认激活的视图
+   */
+  defaultActiveView?: DesignerViewType;
 }
 
 /**
@@ -23,6 +27,7 @@ interface ICreateEngineOptions {
  */
 export function createEngine({
   workspace,
+  defaultActiveView = 'design',
   defaultSimulatorMode = 'desktop',
   defaultActiveSidebarPanel = '',
 }: ICreateEngineOptions) {
@@ -31,6 +36,7 @@ export function createEngine({
     designer: new Designer({
       workspace,
       simulator: defaultSimulatorMode,
+      activeView: defaultActiveView,
       activeSidebarPanel: defaultActiveSidebarPanel,
     }),
   });

--- a/packages/core/src/models/designer.ts
+++ b/packages/core/src/models/designer.ts
@@ -20,6 +20,10 @@ interface IDesignerOptions {
   workspace: IWorkspace;
   simulator?: SimulatorNameType | ISimulatorType;
   activeSidebarPanel?: string;
+  /**
+   * 默认激活的视图模式
+   */
+  activeView?: DesignerViewType;
 }
 
 const ISimulatorTypes: Record<string, ISimulatorType> = {
@@ -112,7 +116,11 @@ export class Designer {
   constructor(options: IDesignerOptions) {
     this.workspace = options.workspace;
 
-    const { simulator, activeSidebarPanel: defaultActiveSidebarPanel } = options;
+    const {
+      simulator,
+      activeSidebarPanel: defaultActiveSidebarPanel,
+      activeView: defaultActiveView,
+    } = options;
 
     // 默认设计器模式
     if (simulator) {
@@ -122,6 +130,11 @@ export class Designer {
     // 默认展开的侧边栏
     if (defaultActiveSidebarPanel) {
       this.setActiveSidebarPanel(defaultActiveSidebarPanel);
+    }
+
+    // 默认激活的视图
+    if (defaultActiveView) {
+      this.setActiveView(defaultActiveView);
     }
 
     makeObservable(this, {


### PR DESCRIPTION
``` js
// 新增 defaultActiveView，支持声明默认视图
const engine = createEngine({
  workspace,
  defaultActiveView: 'design'
});
```