### PR TITLE
feat: use addEventListener to bind iframe event handlers

### DIFF
--- a/packages/sandbox/src/code-sandbox/index.tsx
+++ b/packages/sandbox/src/code-sandbox/index.tsx
@@ -121,12 +121,12 @@ export class CodeSandbox extends React.Component<CodeSandboxProps, CodeSandboxSt
     externalResources: this.props.externalResources,
   });
 
-  normalizeEventType = (eventType) =>
+  normalizeEventType = (eventType: string) =>
     eventType === 'onTango'
       ? TangoEventName.DesignerAction
       : eventType.replace(/^on/, '').toLowerCase();
 
-  bindEvents = (eventHandlers) => {
+  bindEvents = (eventHandlers: EventHandlers) => {
     Object.keys(eventHandlers).forEach((eventType) => {
       this.iframe?.contentDocument?.addEventListener(
         this.normalizeEventType(eventType),
@@ -135,7 +135,7 @@ export class CodeSandbox extends React.Component<CodeSandboxProps, CodeSandboxSt
     });
   };
 
-  unbindEvents = (eventHandlers) => {
+  unbindEvents = (eventHandlers: EventHandlers) => {
     Object.keys(eventHandlers).forEach((eventType) => {
       this.iframe?.contentDocument?.removeEventListener(
         this.normalizeEventType(eventType),


### PR DESCRIPTION
调整沙箱事件绑定的实现，从直接在 DOM 上定义事件属性改为使用 `addEventListener` 注册事件回调函数。

例如，以前的事件定义类似于 `iframe.contentDocument.onkeydown = handler`，现在的方式改为了 `iframe.contentDocument.addEventListener('keydown', handler)`

调整后，可以修复和避免平台或沙箱内部的页面使用相同的方式（即 `document.onkeydown = pageHandler`）绑定事件时，沙箱自身 `useDnd()` 里的回调函数会被覆盖的问题。