### PR TITLE
feat: custom state view displayed properties

### DIFF
--- a/packages/designer/src/sidebar/outline-panel/index.tsx
+++ b/packages/designer/src/sidebar/outline-panel/index.tsx
@@ -9,9 +9,17 @@ export interface OutlineViewProps extends ComponentsTreeProps {
    * 展示状态视图
    */
   showStateView?: boolean;
+  /**
+   * 状态视图中可展示的子节点
+   */
+  pickStateViewProperties?: string[];
 }
 
-export function OutlinePanel({ showStateView = true, ...treeProps }: OutlineViewProps) {
+export function OutlinePanel({
+  showStateView = true,
+  pickStateViewProperties,
+  ...treeProps
+}: OutlineViewProps) {
   return (
     <Box height="100%" position="relative">
       <CollapsePanel
@@ -23,7 +31,7 @@ export function OutlinePanel({ showStateView = true, ...treeProps }: OutlineView
       >
         <ComponentsTree {...treeProps} />
       </CollapsePanel>
-      {showStateView && <StateTree />}
+      {showStateView && <StateTree pickProperties={pickStateViewProperties} />}
     </Box>
   );
 }

--- a/packages/designer/src/sidebar/outline-panel/state-tree.tsx
+++ b/packages/designer/src/sidebar/outline-panel/state-tree.tsx
@@ -22,15 +22,22 @@ function processTango(obj: any = {}, index = 0) {
   return ret;
 }
 
-export const StateTree = observer(() => {
+export interface StateTreeProps {
+  /**
+   * 状态视图中可展示的子节点
+   */
+  pickProperties?: string[];
+}
+
+const defaultPickProperties = ['stores', 'pageStore', 'services', 'config'];
+
+export const StateTree = observer(({ pickProperties }: StateTreeProps) => {
   const sandboxQuery = useSandboxQuery();
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
-  const tangoContext = pick(sandboxQuery.window['tango'] || {}, [
-    'stores',
-    'pageStore',
-    'services',
-    'config',
-  ]);
+  const tangoContext = pick(
+    sandboxQuery.window['tango'] || {},
+    pickProperties || defaultPickProperties,
+  );
   const callback = () => {
     forceUpdate();
   };


### PR DESCRIPTION
Example: 

```
<Sidebar.Item
  key="outline"
  label="结构"
  icon={<BuildOutlined />}
  widgetProps={{
    pickStateViewProperties: [
      'stores',
      'pageStore',
      'config',
      'refs',
    ]
  }} />
```