### PR TITLE
IDE 刷新 / AST 同步时机优化（待定）

### DIFF
--- a/packages/core/src/helpers/string.ts
+++ b/packages/core/src/helpers/string.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { camelCase, upperCamelCase } from '@music163/tango-helpers';
+import { camelCase, logger, upperCamelCase } from '@music163/tango-helpers';
 import { FileType } from './../types';
 
 /**
@@ -138,8 +138,14 @@ const prettierPlugins = (window as any).prettierPlugins;
  * @returns the formatted code
  */
 export function formatCode(code: string, parser = 'babel') {
+  // 格式化出错时，返回原始代码，避免 AST 解析崩溃
   if (prettier && prettierPlugins) {
-    return prettier.format(code, { parser, plugins: prettierPlugins });
+    try {
+      return prettier.format(code, { parser, plugins: prettierPlugins });
+    } catch (error) {
+      logger.error('[prettier lint code failed!]', error);
+      return code;
+    }
   }
   return code;
 }

--- a/packages/designer/src/toolbar/mode-switch.tsx
+++ b/packages/designer/src/toolbar/mode-switch.tsx
@@ -50,6 +50,7 @@ export const ModeSwitchTool = observer(() => {
         onClick={() => {
           designer.setActiveView('dual'); // 切换到双屏视图
           designer.setActiveSidebarPanel(''); // 关闭左侧面板
+          designer.toggleIsPreview(true); // 切换到预览模式
           activeFileCheck();
         }}
         tooltip="双屏视图"

--- a/packages/designer/src/toolbar/mode-switch.tsx
+++ b/packages/designer/src/toolbar/mode-switch.tsx
@@ -27,6 +27,7 @@ export const ModeSwitchTool = observer(() => {
         selected={designer.activeView === 'design'}
         onClick={() => {
           designer.setActiveView('design');
+          designer.toggleIsPreview(false); // 切回设计模式
         }}
         tooltip="设计视图"
       >


### PR DESCRIPTION
# 问题背景 （临时错误代码不同步引擎，IDE 代码同步 AST 过于高频，且没有必要）
- IDE 中编写（临时）错误代码，代码易被回滚，**原因：IDE 组件内监听 activeFile 或 files 更新，[此时 IDE 会被自动 refresh 导致代码丢失](https://github.com/BoBoooooo/tango/blob/fix/ast-sync-timing/packages/designer/src/editor.tsx#L49
)**
- IDE 模式下，引擎 AST 的解析是多余环节，此时用户不会使用设计视图
- IDE 模式下，由于每次 IDE 失焦均会触发 updateFile AST 同步，在 JS 大文件时，有丢帧卡顿现象，造成性能浪费
- IDE 编写的代码是否是最高优先级（目前 IDE 内的代码有错误时不会同步至 workspace）
- IDE 是否可以编写语法错误的代码（如果支持 IDE 编写错误代码，在 code2ast 时会失败，在 prettier 格式化时会失败(已加 try catch)）

目前 IDE 合法的代码同步至 Workspace 时机:

- IDE 失焦 （该时机也不能直接去掉，也容易造成代码丢失）
- IDE 保存快捷键

**如果视为纯在线编码的沙箱，应该允许用户任意输入**

# 可能的解决方案（重构 IDE 刷新时机 / AST 解析时机）
## Workspace.File 新增 tempCode 字段

- code
- cleanCode
- ast
- tempCode: 最高优先级，临时代码直传沙箱(支持错误代码)，不走 AST 解析，缺点：增加引擎理解/实现成本

## AST 同步时机调整

### 进入 WEBIDE （预览模式）

进入 IDE 时，ast2code 同步一次代码至 IDE 
此时保持预览模式，纯 IDE + 沙箱场景，没有引擎 AST 解析干预

### 退出 IDE (切回设计模式)
离开 IDE 时，code2ast(updateFile) 同步一次 IDE 代码至 Workspace

# 问题

IDE 模式下，会造成可视化面板跟 IDE 内代码不同步的问题

可能的解决方式：
- 直接屏蔽所有可视化功能，状态/接口/新建页面等所有可视化面板均屏蔽，用户手写代码
- 较为刚需的可视化能力，单独走事件通知 IDE 局部刷新某个文件

# 结论待定
对整体 Tango 设计有较大影响面，如约束用户禁止写错误代码，允许错误代码被回滚的问题，上述均可暂不处理

