### PR TITLE
fix: show right panel when design view select node & optimize editor css

### DIFF
--- a/packages/designer/src/dnd/use-dnd.ts
+++ b/packages/designer/src/dnd/use-dnd.ts
@@ -137,6 +137,8 @@ export function useDnd({
     const data = sandboxQuery.getDraggableParentsData(e.target as HTMLElement, true);
     if (data && data.id) {
       selectSource.select(data);
+      // 画布选中节点时，自动唤起 right-panel
+      designer.toggleRightPanel(true);
     }
   };
 

--- a/packages/designer/src/editor.tsx
+++ b/packages/designer/src/editor.tsx
@@ -81,6 +81,7 @@ export const CodeEditor = observer((props: CodeEditorProps) => {
     designer.activeView === 'dual'
       ? {
           borderLeft: 'solid 1px var(--tango-colors-line2)',
+          borderRight: 'solid 1px var(--tango-colors-line2)',
         }
       : {};
 


### PR DESCRIPTION
- 画布模式下，选中节点时自动唤起 right-panel
- 左 IDE 右沙箱，双屏模式下，新增右边框线